### PR TITLE
fix: exclude AuthProvider from StrictMode in local development to prevent auth problems

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 import {withSentryConfig} from "@sentry/nextjs";
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    reactStrictMode: false,
     output: "standalone",
     basePath: process.env.NEXT_PUBLIC_BASE_PATH,
     experimental: {

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,13 +2,16 @@
 
 import {NextUIProvider} from '@nextui-org/react';
 import {AuthProvider} from '@/app/AuthProvider';
+import React from 'react';
 
 export function Providers({children}: { children: React.ReactNode }) {
   return (
     <AuthProvider>
-      <NextUIProvider locale='nb-NO'>
-        {children}
-      </NextUIProvider>
+      <React.StrictMode>
+        <NextUIProvider locale='nb-NO'>
+          {children}
+        </NextUIProvider>
+      </React.StrictMode>
     </AuthProvider>
   );
 }


### PR DESCRIPTION
Local dev without disabling strict mode for the whole app in the config caused auth problems as the code to exchange to token was sent twice, causing infinite loop of re-rendering. This PR disables strict mode in the config while adding it with <React.StrictMode> below <AuthProvider> in the tree.

This PR should have no effect any environment except development