### PR TITLE
refactor(ui): make reusable ui components for buttons and modals (TT-1979)

### DIFF
--- a/__tests__/components/ErrorModal.test.tsx
+++ b/__tests__/components/ErrorModal.test.tsx
@@ -1,33 +1,73 @@
-import {beforeEach, expect, test, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {afterEach, expect, test, vi} from 'vitest';
+import {cleanup, fireEvent, render, screen, within} from '@testing-library/react';
 import ErrorModal from '@/components/ErrorModal';
-import {userEvent} from '@testing-library/user-event';
+import {ReactNode} from 'react';
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual('react-dom');
+  return {
+    ...actual
+  };
+});
+
+vi.mock('next/link', () => ({
+  default: (props: {
+    href: string;
+    children: ReactNode;
+  }) => <a href={props.href}>{props.children}</a>,
+}));
 
 
-beforeEach(() => {
-  render(<ErrorModal text='Feilmelding'/>);
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
 });
 
 test('ErrorModal should render with text and button', () => {
-  expect(screen.getByText('Feilmelding', {exact: false})).toBeTruthy();
-  expect(screen.getByText('Kontakt tekst-teamet', {exact: false})).toBeTruthy();
-  expect(screen.getByText('dersom problemet vedvarer', {exact: false})).toBeTruthy();
-  expect(screen.getByRole('button', {name: 'Lukk'})).toBeTruthy();
+  render(<ErrorModal text='Feilmelding' />);
+
+  const modalContent = screen.getByRole('dialog');
+
+  expect(within(modalContent).getByText(content => {
+    return content.includes('Feilmelding');
+  })).toBeTruthy();
+
+  expect(within(modalContent).getByText(content => {
+    return content.includes('Kontakt tekst-teamet');
+  })).toBeTruthy();
+
+  expect(within(modalContent).getByText(content => {
+    return content.includes('dersom problemet vedvarer');
+  })).toBeTruthy();
+
+  expect(screen.getByText('Lukk')).toBeTruthy();
 });
 
-test('ErrorModal should close when button is pressed', async () => {
-  screen.getByRole('button', {name: 'Lukk'}).click();
-  await vi.waitFor(() => expect(screen.queryByText('Feilmelding', {exact: false})).toBeNull());
+test('ErrorModal should close when button is pressed', () => {
+  const exitMock = vi.fn();
+  render(<ErrorModal text='Feilmelding' onExit={exitMock} />);
+
+  fireEvent.click(screen.getByText('Lukk'));
+  expect(exitMock).toHaveBeenCalled();
 });
 
-test('ErrorModal should close when escape is pressed', async () => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
-  await userEvent.keyboard('{Escape}');
-  await vi.waitFor(() => expect(screen.queryByText('Feilmelding', {exact: false})).toBeNull());
+test('ErrorModal should close when escape is pressed', () => {
+  const exitMock = vi.fn();
+  render(<ErrorModal text='Feilmelding' onExit={exitMock} />);
+
+  fireEvent.keyDown(document, { key: 'Escape' });
+  expect(exitMock).toHaveBeenCalled();
 });
 
-test('ErrorModal should close when outside is clicked', async () => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
-  await userEvent.click(document.body);
-  await vi.waitFor(() => expect(screen.queryByText('Feilmelding', {exact: false})).toBeNull());
+test('ErrorModal should close when outside is clicked', () => {
+  const exitMock = vi.fn();
+  render(<ErrorModal text='Feilmelding' onExit={exitMock} />);
+
+  const overlayElements = document.querySelectorAll('.fixed.inset-0');
+  if (overlayElements.length > 0) {
+    fireEvent.click(overlayElements[0]);
+    expect(exitMock).toHaveBeenCalled();
+  } else {
+    throw new Error('No overlay element found');
+  }
 });

--- a/src/app/AuthProvider.tsx
+++ b/src/app/AuthProvider.tsx
@@ -60,7 +60,7 @@ export const AuthProvider = ({children}: { children: React.ReactNode }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleIsAuthenticated = (newUser: UserToken, shouldRouteToRoot: boolean = false) => {
+  const handleIsAuthenticated = useCallback((newUser: UserToken, shouldRouteToRoot: boolean = false) => {
     if (newUser) {
       setUser(newUser);
       setAuthenticated(true);
@@ -70,7 +70,7 @@ export const AuthProvider = ({children}: { children: React.ReactNode }) => {
         router.push('/');
       }
     }
-  };
+  }, [router]);
 
   const refreshToken = useCallback(async () => {
     return refresh();
@@ -92,7 +92,7 @@ export const AuthProvider = ({children}: { children: React.ReactNode }) => {
           });
       }, (1000 * 60 * 4.75))); // Refresh every 4.75 minutes (fifteen seconds before expiry)
     }
-  }, [handleNotAuthenticated, intervalId, refreshToken, user?.expires]);
+  }, [handleNotAuthenticated, handleIsAuthenticated, intervalId, refreshToken, user?.expires]);
 
   useEffect(() => {
     void setIntervalToRefreshAccessToken();

--- a/src/app/[id]/create/page.tsx
+++ b/src/app/[id]/create/page.tsx
@@ -7,7 +7,6 @@ import {fetchNewspaperTitleFromCatalog} from '@/services/catalog.data';
 import {CatalogTitle} from '@/models/CatalogTitle';
 import {Field, Form, Formik} from 'formik';
 import {useRouter, useSearchParams} from 'next/navigation';
-import {Button} from '@nextui-org/button';
 import {NotFoundError} from '@/models/Errors';
 import SuccessModal from '@/components/SuccessModal';
 import {FaArrowAltCircleLeft, FaQuestionCircle, FaSave} from 'react-icons/fa';
@@ -17,6 +16,7 @@ import {Spinner, Tooltip} from '@nextui-org/react';
 import ContactInformationForm from '@/components/ContactInformationForm';
 import ReleasePatternForm from '@/components/ReleasePatternForm';
 import {TitleContactInfo} from '@/models/TitleContactInfo';
+import AccessibleButton from '@/components/ui/AccessibleButton';
 
 export default function Page({params}: { params: { id: string } }) {
   const router = useRouter();
@@ -102,14 +102,15 @@ export default function Page({params}: { params: { id: string } }) {
 
   return (
     <div className='flex w-9/12 flex-col max-w-screen-lg items-start'>
-      <Button
+      <AccessibleButton
         type='button'
-        className='abort-button-style'
+        variant='flat'
+        color='secondary'
         startContent={<FaArrowAltCircleLeft/>}
         onClick={() => router.push(`/${params.id}?title=${titleString}`)}
       >
         Tilbake til titteloversikt
-      </Button>
+      </AccessibleButton>
 
       <div className='flex flex-row justify-between mt-6 mb-10'>
         <div>
@@ -232,15 +233,16 @@ export default function Page({params}: { params: { id: string } }) {
                   {isSubmitting ? (
                     <Spinner size={'lg'} className='py-3'/>
                   ) : (
-                    <Button
+                    <AccessibleButton
                       type='submit'
+                      variant='solid'
+                      color='primary'
                       disabled={isSubmitting || !isValid}
                       size='lg'
                       endContent={<FaSave/>}
-                      className='save-button-style'
                     >
                       Lagre
-                    </Button>
+                    </AccessibleButton>
                   )}
                 </div>
               </Form>

--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -204,16 +204,16 @@ export default function Page({params}: { params: { id: string } }) {
         <div className='flex flex-row flex-wrap self-center w-full justify-evenly'>
           <div className='flex flex-col grow mx-10'>
             <div>
-              <div className='w-full mb-3'>
+              <div className='w-full mb-3 border-style p-3'>
                 {titleString ? (
                   <h1 className="top-title-style">{titleString}</h1>
                 ) : (
                   <p>Henter tittel ...</p>
                 )}
-                <div className="flex justify-center gap-2">
+                <div className="flex justify-start gap-2">
                   <p className="group-title-style"> Katalog ID: </p>
                   <a className="group-content-style underline" href={titleLink} target="_blank">
-                    <div className="flex flex-row gap-2">
+                    <div className="flex flex-row gap-2 items-center">
                       <p>{params.id}</p>
                       <FaExternalLinkAlt/>
                     </div>
@@ -225,7 +225,7 @@ export default function Page({params}: { params: { id: string } }) {
                     text={`Denne avisen ble avsluttet ${catalogDateStringToNorwegianDateString(catalogTitle.endDate)}`}
                   />
                 )}
-                <div className='flex flex-row justify-between items-center mt-4'>
+                <div className='flex flex-col justify-between gap-2.5 mt-4'>
                   <EditTextInput
                     name='Hyllesignatur'
                     value={titleContact.title.shelf ?? ''}
@@ -233,35 +233,35 @@ export default function Page({params}: { params: { id: string } }) {
                     onSuccess={updateShelfLocally}
                     className='w-96'
                   />
+
+                  <div className='flex flex-row flex-wrap items-center'>
+                    {boxFromDb ? (
+                      <>
+                        <p className="group-title-style">Eske til registrering: </p>
+                        <p className="group-content-style ml-2">{boxToString(boxFromDb)}</p>
+                      </>
+                    ) : (<p className="group-content-style"> Ingen eske registrert </p>)
+                    }
+
+                    {showBoxRegistrationModal &&
+                        <BoxRegistrationModal
+                          text='Registrer en ny eske'
+                          closeModal={() => setShowBoxRegistrationModal(false)}
+                          updateBoxInfo={setBoxFromDb}
+                          titleName={titleString ?? ''}
+                          titleId={params.id}/>
+                    }
+
+                    <AccessibleButton
+                      endContent={<FaBoxOpen size={18}/>}
+                      variant='flat'
+                      color='secondary'
+                      className='ml-2'
+                      onClick={() => setShowBoxRegistrationModal(true)}>
+                      Ny eske
+                    </AccessibleButton>
+                  </div>
                 </div>
-              </div>
-
-              <div className='flex flex-row flex-wrap items-center'>
-                {boxFromDb ? (
-                  <>
-                    <p className="group-title-style">Eske til registrering: </p>
-                    <p className="group-content-style ml-2">{boxToString(boxFromDb)}</p>
-                  </>
-                ) : (<p className="group-content-style"> Ingen eske registrert </p>)
-                }
-
-                {showBoxRegistrationModal &&
-                    <BoxRegistrationModal
-                      text='Registrer en ny eske'
-                      closeModal={() => setShowBoxRegistrationModal(false)}
-                      updateBoxInfo={setBoxFromDb}
-                      titleName={titleString ?? ''}
-                      titleId={params.id}/>
-                }
-
-                <AccessibleButton
-                  endContent={<FaBoxOpen size={18}/>}
-                  variant='flat'
-                  color='secondary'
-                  className='ml-2'
-                  onClick={() => setShowBoxRegistrationModal(true)}>
-                  Ny eske
-                </AccessibleButton>
               </div>
 
               {boxFromDb ? (
@@ -274,7 +274,7 @@ export default function Page({params}: { params: { id: string } }) {
           </div>
 
           <div className="flex flex-col w-96">
-            <div className='items-start mt-16 w-72 mb-6'>
+            <div className='items-start mb-3 w-full border-style p-3'>
               {titleContact &&
                   <NotesComponent
                     notes={titleContact.title.notes ?? ''}

--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -16,7 +16,6 @@ import {
 import {box, contact_info, title} from '@prisma/client';
 import {useSearchParams} from 'next/navigation';
 import {NotFoundError} from '@/models/Errors';
-import {Button} from '@nextui-org/button';
 import {FaBoxOpen, FaEdit, FaExternalLinkAlt, FaSave} from 'react-icons/fa';
 import BoxRegistrationModal from '@/components/BoxRegistrationModal';
 import NotesComponent from '@/components/NotesComponent';
@@ -35,6 +34,7 @@ import ContactInformation from '@/components/ContactInformation';
 import ReleasePattern from '@/components/ReleasePattern';
 import TitleNotFound from '@/components/TitleNotFound';
 import SuccessAlert from '@/components/SuccessAlert';
+import AccessibleButton from '@/components/ui/AccessibleButton';
 
 export default function Page({params}: { params: { id: string } }) {
   const [titleString, setTitleString] = useState<string>();
@@ -254,13 +254,14 @@ export default function Page({params}: { params: { id: string } }) {
                       titleId={params.id}/>
                 }
 
-                <Button
-                  endContent={<FaBoxOpen size={25}/>}
-                  size={'md'}
-                  className="edit-button-style ml-4 [&]:text-medium"
+                <AccessibleButton
+                  endContent={<FaBoxOpen size={18}/>}
+                  variant='flat'
+                  color='secondary'
+                  className='ml-2'
                   onClick={() => setShowBoxRegistrationModal(true)}>
                   Ny eske
-                </Button>
+                </AccessibleButton>
               </div>
 
               {boxFromDb ? (
@@ -341,28 +342,28 @@ export default function Page({params}: { params: { id: string } }) {
                             <Spinner className='self-center p-1' size='lg'/>
                           ) : (
                             <div className='flex flex-row justify-between w-full'>
-                              <Button
-                                type="submit"
-                                size="lg"
-                                className="save-button-style"
-                                endContent={<FaSave size={25}/>}
-                                disabled={!isValid || isSubmitting}
-                              >
-                                Lagre
-                              </Button>
-
-                              <Button
+                              <AccessibleButton
                                 type="button"
-                                size="lg"
-                                className="abort-button-style"
-                                endContent={<ImCross size={25}/>}
+                                variant='flat'
+                                color='secondary'
+                                endContent={<ImCross size={18}/>}
                                 onClick={() => {
                                   resetForm();
                                   setIsEditing(false);
                                 }}
                               >
                                 Avbryt
-                              </Button>
+                              </AccessibleButton>
+
+                              <AccessibleButton
+                                type="submit"
+                                variant='solid'
+                                color='primary'
+                                endContent={<FaSave size={18}/>}
+                                disabled={!isValid || isSubmitting}
+                              >
+                                Lagre
+                              </AccessibleButton>
                             </div>
                           )}
                         </Form>
@@ -385,15 +386,16 @@ export default function Page({params}: { params: { id: string } }) {
                       {titleContact.title.release_pattern &&
                           <ReleasePattern releasePattern={titleContact.title.release_pattern}/>
                       }
-                      <Button
+                      <AccessibleButton
                         type="button"
-                        size="lg"
-                        className="edit-button-style mt-5"
-                        endContent={<FaEdit size={25}/>}
+                        variant='flat'
+                        color='secondary'
+                        className='mt-1'
+                        endContent={<FaEdit size={18}/>}
                         onClick={() => setIsEditing(true)}
                       >
                         Rediger
-                      </Button>
+                      </AccessibleButton>
                     </div>
                   }
                 </>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,29 +24,6 @@ input[type=number] {
     @apply text-blue-500 font-bold;
 }
 
-.edit-button-style {
-    @apply bg-blue-300 enabled:hover:bg-blue-500;
-    @apply text-xl font-bold text-black;
-    @apply disabled:bg-gray-400;
-}
-
-.abort-button-style {
-    @apply bg-yellow-300 enabled:hover:bg-yellow-500;
-    @apply text-medium font-bold text-black;
-}
-
-.save-button-style {
-    @apply bg-green-300 enabled:hover:bg-green-500;
-    @apply text-xl font-bold text-black;
-    @apply disabled:bg-gray-400;
-}
-
-.delete-button-style {
-    @apply bg-red-400 enabled:hover:bg-red-600;
-    @apply text-medium font-bold text-black;
-    @apply disabled:bg-gray-400;
-}
-
 .top-title-style {
     @apply text-4xl font-bold text-black;
 }
@@ -81,7 +58,7 @@ input[type=number] {
 
 /* NB: Må ha både margin og padding av ukjent grunn for at det skal bli mellomrom mellom border og innhold */
 .border-style {
-    @apply border-5 rounded-xl border-blue-200;
+    @apply border-1 border-slate-200 rounded-xl bg-foreground-50 shadow-md;
 }
 
 [data-today='true'] {

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -1,8 +1,7 @@
-import {FC, useCallback, useEffect, useState} from 'react';
-import {Button} from '@nextui-org/button';
-import {useOutsideClick} from '@/hooks/useOutsideClick';
-import {Spinner} from '@nextui-org/react';
-
+import React, {FC, useCallback, useState} from 'react';
+import Modal from '@/components/ui/Modal';
+import { FaExclamationTriangle } from 'react-icons/fa';
+import { Spinner } from '@nextui-org/react';
 
 interface ConfirmationModalProps {
   showModal: boolean;
@@ -21,77 +20,51 @@ const ConfirmationModal: FC<ConfirmationModalProps> = ({
   buttonOnClick,
   onExit
 }) => {
-  const ref = useOutsideClick(() => handleExit());
-  const [currentShowModal, setCurrentShowModal] = useState<boolean>(showModal ?? true);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const handleExit = useCallback(() => {
+  const handleClose = useCallback(() => {
     if (onExit) onExit();
-    setCurrentShowModal(false);
     setIsLoading(false);
   }, [onExit]);
 
-  const handleConfirm = useCallback(() => {
-    setIsLoading(true);
-    if (buttonOnClick)  {
-      void buttonOnClick().then(() => setIsLoading(false));
+  const handleConfirmClick = useCallback(() => {
+    if (buttonOnClick) {
+      setIsLoading(true);
+      // Using void to explicitly indicate we're ignoring the promise
+      void buttonOnClick().finally(() => {
+        setIsLoading(false);
+      });
     } else {
-      handleExit();
+      handleClose();
     }
-  }, [buttonOnClick, handleExit]);
+  }, [buttonOnClick, handleClose]);
 
-  useEffect(() => {
-    setCurrentShowModal(showModal ?? true);
-  }, [showModal]);
-
-  useEffect(() => {
-    function handleEscapeKeyDown(event: KeyboardEvent) {
-      if (event.code === 'Escape') {
-        event.preventDefault();
-        handleExit();
-      }
-    }
-    setTimeout(() => document.addEventListener('keydown', handleEscapeKeyDown));
-    return () => document.removeEventListener('keydown', handleEscapeKeyDown);
-  }, [handleExit]);
-
-  if (!currentShowModal) return null;
 
   return (
-    <div className='fixed inset-0 bg-gray-600 bg-opacity-50 h-full w-full flex items-center justify-center z-40'>
-      <div ref={ref} className='p-8 border border-blue-400 w-2/5 rounded-xl bg-white'>
-        <div className='text-center'>
-          <h3 className='top-title-style'> {header} </h3>
-          <p className='group-content-style mt-3 whitespace-pre-wrap'>
-            {text}
-          </p>
-          <div className='flex flex-row justify-evenly'>
-            <Button
-              type='button'
-              size='lg'
-              className='abort-button-style mt-5'
-              onClick={() => handleExit()}
-            >
-              Avbryt
-            </Button>
-            {buttonText &&
-              <Button
-                type='button'
-                size='lg'
-                className='save-button-style mt-5'
-                disabled={isLoading}
-                onClick={() => {
-                  handleConfirm();
-                }}
-                endContent={isLoading ? <Spinner size={'sm'}/> : undefined}
-              >
-                {buttonText}
-              </Button>
-            }
-          </div>
+    <Modal
+      isOpen={showModal}
+      onClose={handleClose}
+      title={header}
+      contentClassName="border border-blue-400 rounded-xl bg-white"
+      primaryActionText={buttonText}
+      onPrimaryAction={buttonText ? handleConfirmClick : undefined}
+      secondaryActionText="Avbryt"
+    >
+      <div className="flex items-center justify-center flex-col">
+        <div className="rounded-full bg-yellow-100 p-3 mb-4">
+          <FaExclamationTriangle className="text-yellow-500" size={24} />
+        </div>
+        <div className="group-content-style mt-3 whitespace-pre-wrap text-center">
+          {isLoading ? (
+            <div className="flex justify-center items-center py-4">
+              <Spinner size="lg" />
+            </div>
+          ) : (
+            text
+          )}
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/components/ContactInformationForm.tsx
+++ b/src/components/ContactInformationForm.tsx
@@ -3,7 +3,7 @@ import React, {ChangeEvent, FC} from 'react';
 import {Field, FieldArray} from 'formik';
 import {TitleContactInfo} from '@/models/TitleContactInfo';
 import {FaCircleMinus} from 'react-icons/fa6';
-import {Button} from '@nextui-org/button';
+import AccessibleButton from '@/components/ui/AccessibleButton';
 
 interface ContactInformationProps {
   values: TitleContactInfo;
@@ -59,19 +59,21 @@ const ContactInformationForm: FC<ContactInformationProps> = ({values, handleChan
                         onBlur={handleBlur}
                         value={contact.contact_value ?? ''}
                       />
-                      <button
+                      <AccessibleButton
                         type="button"
-                        className="row-action-button-style"
+                        isIconOnly
                         onClick={() => handleRemove(values, index)}
+                        variant="light"
+                        color="primary"
                       >
                         <FaCircleMinus size={24} className='text-blue-500'/>
-                      </button>
+                      </AccessibleButton>
                     </div>
                   </div>
                 </div>
               )
             ))}
-            <Button
+            <AccessibleButton
               type="button"
               variant="light"
               color="primary"
@@ -79,7 +81,7 @@ const ContactInformationForm: FC<ContactInformationProps> = ({values, handleChan
               onClick={() => handleAdd(values, 'phone')}
             >
               + Legg til telefon
-            </Button>
+            </AccessibleButton>
           </>
         )}
       />
@@ -102,19 +104,21 @@ const ContactInformationForm: FC<ContactInformationProps> = ({values, handleChan
                         onBlur={handleBlur}
                         value={contact.contact_value ?? ''}
                       />
-                      <button
+                      <AccessibleButton
                         type="button"
-                        className="row-action-button-style"
+                        variant="light"
+                        isIconOnly
+                        color="primary"
                         onClick={() => handleRemove(values, index)}
                       >
                         <FaCircleMinus size={24} className='text-blue-500'/>
-                      </button>
+                      </AccessibleButton>
                     </div>
                   </div>
                 </div>
               )
             ))}
-            <Button
+            <AccessibleButton
               type="button"
               variant="light"
               color="primary"
@@ -122,7 +126,7 @@ const ContactInformationForm: FC<ContactInformationProps> = ({values, handleChan
               onClick={() => handleAdd(values, 'email')}
             >
               + Legg til e-post
-            </Button>
+            </AccessibleButton>
           </>
         )}
       />

--- a/src/components/EditTextInput.tsx
+++ b/src/components/EditTextInput.tsx
@@ -94,14 +94,13 @@ const EditTextInput: FC<EditTextInputProps> = (props: EditTextInputProps) => {
                 variant='flat'
                 className='ml-1'
                 data-testid='abort-button'
+                onClick={() => setIsEditing(false)}
               >
                 <IconContext.Provider value={{
                   className: 'icon-style [&]:text-xl',
                   size: '1.5em'
                 }}>
-                  <ImCross
-                    onClick={() => setIsEditing(false)}
-                  />
+                  <ImCross />
                 </IconContext.Provider>
               </AccessibleButton>
             </Form>

--- a/src/components/EditTextInput.tsx
+++ b/src/components/EditTextInput.tsx
@@ -5,6 +5,7 @@ import {IconContext} from 'react-icons';
 import {ImCross} from 'react-icons/im';
 import ErrorModal from '@/components/ErrorModal';
 import {Spinner} from '@nextui-org/react';
+import AccessibleButton from '@/components/ui/AccessibleButton';
 
 
 interface EditTextInputProps {
@@ -71,29 +72,38 @@ const EditTextInput: FC<EditTextInputProps> = (props: EditTextInputProps) => {
               {isSubmitting ? (
                 <Spinner size='sm' className='px-1' />
               ) : (
-                <button
+                <AccessibleButton
                   type='submit'
                   disabled={isSubmitting || !dirty}
+                  isIconOnly
+                  color='primary'
+                  variant='solid'
                   data-testid='save-button'
                 >
                   <IconContext.Provider value={{
-                    className: 'icon-style save-button-style',
+                    className: 'icon-style [&]:text-xl',
                     size: '1.5em'
                   }}>
                     <FaSave/>
                   </IconContext.Provider>
-                </button>
+                </AccessibleButton>
               )}
-              <button className='ml-1' data-testid='abort-button'>
+              <AccessibleButton
+                isIconOnly
+                color='secondary'
+                variant='flat'
+                className='ml-1'
+                data-testid='abort-button'
+              >
                 <IconContext.Provider value={{
-                  className: 'icon-style abort-button-style [&]:text-xl',
+                  className: 'icon-style [&]:text-xl',
                   size: '1.5em'
                 }}>
                   <ImCross
                     onClick={() => setIsEditing(false)}
                   />
                 </IconContext.Provider>
-              </button>
+              </AccessibleButton>
             </Form>
           )}
         </Formik>
@@ -101,14 +111,20 @@ const EditTextInput: FC<EditTextInputProps> = (props: EditTextInputProps) => {
       ) : (
         <>
           <p className='group-content-style'>{currentValue}</p>
-          <button className='ml-2' onClick={() => setIsEditing(true)}>
+          <AccessibleButton
+            isIconOnly
+            color='secondary'
+            variant='flat'
+            className='ml-2'
+            onClick={() => setIsEditing(true)}
+          >
             <IconContext.Provider value={{
-              className: 'icon-style edit-button-style',
+              className: 'icon-style text-lg',
               size: '1.5em'
             }}>
               <FaEdit/>
             </IconContext.Provider>
-          </button>
+          </AccessibleButton>
         </>
       )}
       {showSuccess && <p className='ml-2'>Lagret!</p>}

--- a/src/components/ErrorModal.tsx
+++ b/src/components/ErrorModal.tsx
@@ -1,8 +1,7 @@
-import {FC, useCallback, useEffect, useState} from 'react';
-import {useOutsideClick} from '@/hooks/useOutsideClick';
-import {Button} from '@nextui-org/button';
+import React, { FC } from 'react';
+import Modal from '@/components/ui/Modal';
 import Link from 'next/link';
-
+import { ImCross } from 'react-icons/im';
 
 interface ErrorModalProps {
   text: string;
@@ -13,58 +12,32 @@ interface ErrorModalProps {
 const ErrorModal: FC<ErrorModalProps> = ({
   text,
   onExit,
-  showModal
+  showModal = true
 }) => {
-  const ref = useOutsideClick(() => handleExit());
-  const [currentShowModal, setCurrentShowModal] = useState<boolean>(showModal ?? true);
-
-  const handleExit = useCallback(() => {
+  const handleClose = () => {
     if (onExit) onExit();
-    setCurrentShowModal(false);
-  }, [onExit]);
-
-  useEffect(() => {
-    function handleEscapeKeyDown(event: KeyboardEvent) {
-      if (event.code === 'Escape') {
-        event.preventDefault();
-        handleExit();
-      }
-    }
-
-    setTimeout(() => document.addEventListener('keydown', handleEscapeKeyDown));
-
-    return () => document.removeEventListener('keydown', handleEscapeKeyDown);
-  }, [handleExit]);
-
-  useEffect(() => {
-    setCurrentShowModal(showModal ?? true);
-  }, [showModal]);
-
-  if (!currentShowModal) return null;
+  };
 
   return (
-    <div className='modal-backdrop'>
-      <div ref={ref} className='modal-style border-red-600 bg-red-300'>
-        <div className='text-center'>
-          <h3 className='top-title-style'> Ojsann... </h3>
-          <p className='group-content-style mt-3 whitespace-pre-wrap'>
-            {text}<br/>Kontakt tekst-teamet
-            <Link href='https://sd.nb.no' className='text-blue-600 font-bold' target='_blank'> her </Link>
-            dersom problemet vedvarer.
-          </p>
-          <div className='flex flex-row justify-evenly'>
-            <Button
-              type='button'
-              size='lg'
-              className='abort-button-style mt-5'
-              onClick={() => handleExit()}
-            >
-              Lukk
-            </Button>
-          </div>
+    <Modal
+      isOpen={showModal}
+      onClose={handleClose}
+      title="Ojsann..."
+      contentClassName="modal-style border-red-600 bg-red-300"
+      secondaryActionText="Lukk"
+      onSecondaryAction={handleClose}
+    >
+      <div className="flex items-center justify-center flex-col">
+        <div className="rounded-full bg-red-100 p-3 mb-4">
+          <ImCross className="text-red-500" size={24} />
+        </div>
+        <div className="group-content-style mt-3 whitespace-pre-wrap text-center">
+          {text}<br/>Kontakt tekst-teamet
+          <Link href='https://sd.nb.no' className='text-blue-600 font-bold' target='_blank'> her </Link>
+          dersom problemet vedvarer.
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -1,6 +1,6 @@
-import {FC, ReactNode, useCallback, useEffect, useState} from 'react';
-import {useOutsideClick} from '@/hooks/useOutsideClick';
-import {Button} from '@nextui-org/button';
+import React, { FC, ReactNode } from 'react';
+import Modal from '@/components/ui/Modal';
+import { FaInfoCircle } from 'react-icons/fa';
 
 interface InfoModalProps {
   header: string;
@@ -13,55 +13,30 @@ const InfoModal: FC<InfoModalProps> = ({
   header,
   content,
   onExit,
-  showModal
+  showModal = true
 }) => {
-  const ref = useOutsideClick(() => handleExit());
-  const [currentShowModal, setCurrentShowModal] = useState<boolean>(showModal ?? true);
-
-  const handleExit = useCallback(() => {
+  const handleClose = () => {
     if (onExit) onExit();
-    setCurrentShowModal(false);
-  }, [onExit]);
-
-  useEffect(() => {
-
-    function handleEscapeKeyDown(event: KeyboardEvent) {
-      if (event.code === 'Escape') {
-        event.preventDefault();
-        handleExit();
-      }
-    }
-
-    setTimeout(() => document.addEventListener('keydown', handleEscapeKeyDown));
-
-    return () => document.removeEventListener('keydown', handleEscapeKeyDown);
-  }, [handleExit]);
-
-  useEffect(() => {
-    setCurrentShowModal(showModal ?? true);
-  }, [showModal]);
-
-  if (!currentShowModal) return null;
+  };
 
   return (
-    <div className='modal-backdrop'>
-      <div ref={ref} className='modal-style border-gray-600 bg-gray-100'>
-        <div className='text-center'>
-          <h3 className='top-title-style'>{header}</h3>
-          <p className='group-content-style mt-3 whitespace-pre-wrap'>{content}</p>
-          <div className='flex flex-row justify-evenly'>
-            <Button
-              type='button'
-              size='lg'
-              className='abort-button-style mt-5'
-              onClick={() => handleExit()}
-            >
-              Lukk
-            </Button>
-          </div>
+    <Modal
+      isOpen={showModal}
+      onClose={handleClose}
+      title={header}
+      contentClassName="modal-style border-gray-600 bg-gray-100"
+      secondaryActionText="Lukk"
+      onSecondaryAction={handleClose}
+    >
+      <div className="flex items-center justify-center flex-col">
+        <div className="rounded-full bg-blue-100 p-3 mb-4">
+          <FaInfoCircle className="text-blue-500" size={24} />
+        </div>
+        <div className="group-content-style mt-3 whitespace-pre-wrap text-center">
+          {content}
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/components/IssueList.tsx
+++ b/src/components/IssueList.tsx
@@ -169,7 +169,8 @@ export default function IssueList(props: {title: title; box: box}) {
   }
 
   return (
-    <div className='w-full mb-6 mt-4 py-10 border-style m-30'>
+    <div className='w-full mb-6 py-3 border-style'>
+      <h1 className="group-title-style text-start mx-6 mb-2"> Aktiv eske ({props.box.id}) </h1>
       { loading ? (
         <Spinner/>
       ) : (

--- a/src/components/IssueList.tsx
+++ b/src/components/IssueList.tsx
@@ -2,8 +2,8 @@ import {box, newspaper, title} from '@prisma/client';
 import React, {ChangeEvent, useCallback, useEffect, useState} from 'react';
 import {deleteIssue, getNewspapersForBoxOnTitle, postNewIssuesForTitle, putIssue} from '@/services/local.data';
 import {Field, FieldArray, Form, Formik} from 'formik';
-import {FaSave, FaTrash} from 'react-icons/fa';
-import {Button, DatePicker, Spinner, Switch, Table, Tooltip} from '@nextui-org/react';
+import {FaPlus, FaSave, FaTrash} from 'react-icons/fa';
+import {DatePicker, Spinner, Switch, Table, Tooltip} from '@nextui-org/react';
 import {TableBody, TableCell, TableColumn, TableHeader, TableRow} from '@nextui-org/table';
 import ErrorModal from '@/components/ErrorModal';
 import ConfirmationModal from '@/components/ConfirmationModal';
@@ -12,6 +12,7 @@ import {FiEdit} from 'react-icons/fi';
 import {ImCross} from 'react-icons/im';
 import * as Yup from 'yup';
 import {checkDuplicateEditions} from '@/utils/validationUtils';
+import AccessibleButton from '@/components/ui/AccessibleButton';
 
 
 export default function IssueList(props: {title: title; box: box}) {
@@ -201,16 +202,18 @@ export default function IssueList(props: {title: title; box: box}) {
                 {({insert, remove}) => (
                   <div className="mx-6">
                     <div className='flex flex-row mb-5 justify-between items-center'>
-                      <Button
+                      <AccessibleButton
+                        endContent={<FaPlus />}
                         type="button"
-                        className="edit-button-style"
+                        variant='flat'
+                        color='primary'
                         disabled={isSubmitting}
                         onClick={() => {
                           insert(0, proposeNewIssue(values.issues));
                         }}
                       >
                         Legg til ny utgave
-                      </Button>
+                      </AccessibleButton>
 
                       {showSuccess &&
                         <p className='font-bold text-lg'> Lagret! </p>
@@ -223,12 +226,14 @@ export default function IssueList(props: {title: title; box: box}) {
                           content='Lagre aller avbryt endring av avisutgave først'
                           isDisabled={!isEditingIssue()}
                         >
-                          <Button
-                            className="save-button-style min-w-28"
+                          <AccessibleButton
+                            endContent={<FaSave size={18}/>}
+                            variant='solid'
+                            color='primary'
                             type="submit"
                             disabled={isSubmitting || isEditingIssue()}
-                            startContent={isSubmitting && <Spinner className='ml-1' size='sm'/>}
-                          >Lagre</Button>
+                            startContent={isSubmitting && <Spinner className='ml-1' size='sm' color='white'/>}
+                          >Lagre</AccessibleButton>
                         </Tooltip>
                       </div>
                     </div>
@@ -245,7 +250,7 @@ export default function IssueList(props: {title: title; box: box}) {
                       </TableHeader>
                       <TableBody>
                         {values.issues.map((issue, index) => (
-                          <TableRow key={index} className={isEditingIssue(index) ? 'bg-blue-200' : ''}>
+                          <TableRow key={index} className={isEditingIssue(index) ? 'bg-blue-50 border-1 border-blue-200' : ''}>
                             <TableCell className="text-lg">
                               {dayOfWeek(issue.date)}
                             </TableCell>
@@ -303,36 +308,47 @@ export default function IssueList(props: {title: title; box: box}) {
                                         <Spinner size='sm' className='mr-2'/>
                                         :
                                         <>
-                                          <Button isIconOnly
-                                            className='save-button-style mr-1 [&]:text-medium [&]:bg-green-400'
+                                          <AccessibleButton
+                                            isIconOnly
+                                            variant='solid'
+                                            color='success'
+                                            className='mr-1'
                                             type='button'
                                             onClick={() => updateIssue(issue)}>
                                             <FaSave/>
-                                          </Button>
-                                          <Button isIconOnly
-                                            className='abort-button-style mr-1'
+                                          </AccessibleButton>
+                                          <AccessibleButton
+                                            isIconOnly
+                                            variant='solid'
+                                            color='warning'
+                                            className='mr-1'
                                             type='button'
                                             onClick={() => stopEditingIssue()}>
                                             <ImCross/>
-                                          </Button>
+                                          </AccessibleButton>
                                         </>
                                       }
                                     </>
                                     :
-                                    <Button isIconOnly
-                                      className={isEditingIssue() ? 'opacity-25 mr-0.5' : 'edit-button-style [&]:text-medium mr-0.5'}
+                                    <AccessibleButton
+                                      isIconOnly
+                                      variant='flat'
+                                      color='primary'
+                                      className={isEditingIssue() ? 'opacity-25 mr-0.5' : 'mr-0.5'}
                                       type='button'
                                       disabled={isEditingIssue()}
                                       onClick={() => startEditingIssue(index)}
                                     >
                                       <FiEdit/>
-                                    </Button>
+                                    </AccessibleButton>
                                   }
                                 </>
                               }
-                              <Button isIconOnly
+                              <AccessibleButton
+                                isIconOnly
                                 type="button"
-                                className='delete-button-style'
+                                variant='flat'
+                                color="danger"
                                 onClick={() => {
                                   if (!newspaperIsSaved(index, values.issues.length)) {
                                     remove(index);
@@ -341,7 +357,7 @@ export default function IssueList(props: {title: title; box: box}) {
                                   }
                                 }}>
                                 <FaTrash size={16}/>
-                              </Button>
+                              </AccessibleButton>
                             </TableCell>
                           </TableRow>
                         ))}

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -1,18 +1,19 @@
 import {useAuth} from '@/app/AuthProvider';
-import {Button} from '@nextui-org/react';
 import {FaSignOutAlt} from 'react-icons/fa';
+import AccessibleButton from '@/components/ui/AccessibleButton';
 
 const LogoutButton = () => {
   const { logout } = useAuth();
 
   return (
-    <Button
-      className="edit-button-style"
-      endContent={<FaSignOutAlt size={25} />}
+    <AccessibleButton
+      variant='flat'
+      color='secondary'
+      endContent={<FaSignOutAlt size={18} />}
       onClick={logout}
     >
       Logg ut
-    </Button>
+    </AccessibleButton>
   );
 };
 

--- a/src/components/NotesComponent.tsx
+++ b/src/components/NotesComponent.tsx
@@ -57,6 +57,8 @@ const NotesComponent: FC<NotesProps> = (props: NotesProps) => {
             <Textarea
               name='notes'
               id='notes'
+              variant='faded'
+              placeholder='Legg til kommentar'
               value={values.notes}
               onChange={handleChange}
               className='mb-2'
@@ -72,7 +74,9 @@ const NotesComponent: FC<NotesProps> = (props: NotesProps) => {
               startContent={isSubmitting && <Spinner size='sm' color='white'/>}
               endContent={<FaSave/>}
               className='w-full min-h-9'
-            >Lagre kommentar</AccessibleButton>
+            >
+              Lagre kommentar
+            </AccessibleButton>
           </Form>
         )}
       </Formik>

--- a/src/components/NotesComponent.tsx
+++ b/src/components/NotesComponent.tsx
@@ -1,10 +1,10 @@
 import {Form, Formik} from 'formik';
 import React, {FC, useState} from 'react';
 import {Textarea} from '@nextui-org/input';
-import {Button} from '@nextui-org/button';
 import {FaSave} from 'react-icons/fa';
 import ErrorModal from '@/components/ErrorModal';
 import {Spinner} from '@nextui-org/react';
+import AccessibleButton from '@/components/ui/AccessibleButton';
 
 interface NotesProps {
   notes: string;
@@ -64,14 +64,15 @@ const NotesComponent: FC<NotesProps> = (props: NotesProps) => {
               maxRows={props.maxRows ?? 5}
               endContent={showSuccess && <p className='italic text-sm'>Lagret!</p>}
             />
-            <Button
+            <AccessibleButton
               type='submit'
-              disabled={isSubmitting || !dirty}
-              startContent={isSubmitting && <Spinner size='sm'/>}
+              isDisabled={isSubmitting || !dirty}
+              variant='flat'
+              color='secondary'
+              startContent={isSubmitting && <Spinner size='sm' color='white'/>}
               endContent={<FaSave/>}
-              size={'sm'}
-              className='save-button-style [&]:text-small w-full min-h-9'
-            >Lagre kommentar</Button>
+              className='w-full min-h-9'
+            >Lagre kommentar</AccessibleButton>
           </Form>
         )}
       </Formik>

--- a/src/components/NumberInput.tsx
+++ b/src/components/NumberInput.tsx
@@ -3,6 +3,7 @@
 import React, {FC} from 'react';
 import {ErrorMessage, FieldProps, useFormikContext} from 'formik';
 import {FaCircleMinus, FaCirclePlus} from 'react-icons/fa6';
+import AccessibleButton from '@/components/ui/AccessibleButton';
 
 interface NumberInputWithButtonsProps extends FieldProps {
   minValue?: number;
@@ -48,12 +49,15 @@ const NumberInputWithButtons: FC<NumberInputWithButtonsProps> = ({
   return (
     <div className='my-1.5'>
       <div className='flex flex-row gap-1'>
-        <button
+        <AccessibleButton
           type='button'
+          isIconOnly
+          variant='light'
+          color='primary'
           onClick={decreaseValue}
         >
-          <FaCircleMinus size={30} className='text-red-500 hover:text-red-700'/>
-        </button>
+          <FaCircleMinus size={30}/>
+        </AccessibleButton>
 
         <input
           type='number'
@@ -61,12 +65,15 @@ const NumberInputWithButtons: FC<NumberInputWithButtonsProps> = ({
           {...props}
         />
 
-        <button
+        <AccessibleButton
           type='button'
+          isIconOnly
+          variant='light'
+          color='primary'
           onClick={increaseValue}
         >
-          <FaCirclePlus size={30} className='text-green-700 hover:text-green-900'/>
-        </button>
+          <FaCirclePlus size={30}/>
+        </AccessibleButton>
 
       </div>
       <div className='mt-1 w-full'>

--- a/src/components/SuccessAlert.tsx
+++ b/src/components/SuccessAlert.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import AccessibleButton from '@/components/ui/AccessibleButton';
 
 interface SuccessAlertProps {
   message: string;
@@ -9,13 +10,13 @@ const SuccessAlert = ({ message, onClick }: SuccessAlertProps) => {
   return (
     <div className='my-2.5 px-2.5 py-1 border-green-500 bg-green-100 border-1 rounded-xl flex justify-between'>
       <p className='text-green-900 p-2'>{ message }</p>
-      <button
+      <AccessibleButton
         type="button"
         className="text-green-900"
         onClick={onClick}
       >
         x
-      </button>
+      </AccessibleButton>
     </div>
   );
 };

--- a/src/components/SuccessAlert.tsx
+++ b/src/components/SuccessAlert.tsx
@@ -11,8 +11,11 @@ const SuccessAlert = ({ message, onClick }: SuccessAlertProps) => {
     <div className='my-2.5 px-2.5 py-1 border-green-500 bg-green-100 border-1 rounded-xl flex justify-between'>
       <p className='text-green-900 p-2'>{ message }</p>
       <AccessibleButton
+        isIconOnly
         type="button"
-        className="text-green-900"
+        variant='light'
+        color='success'
+        className="text-black"
         onClick={onClick}
       >
         x

--- a/src/components/SuccessModal.tsx
+++ b/src/components/SuccessModal.tsx
@@ -1,6 +1,6 @@
-import {FC, useCallback, useEffect} from 'react';
-import {Button} from '@nextui-org/button';
-import {useOutsideClick} from '@/hooks/useOutsideClick';
+import React, { FC } from 'react';
+import Modal from '@/components/ui/Modal';
+import { FaCheck } from 'react-icons/fa';
 
 interface SuccessModalProps {
   text: string;
@@ -15,47 +15,33 @@ const SuccessModal: FC<SuccessModalProps> = ({
   buttonText,
   buttonOnClick,
   onExit,
-  showModal
+  showModal = true
 }) => {
-  const ref = useOutsideClick(() => handleExit());
-
-  const handleExit = useCallback(() => {
+  const handleClose = () => {
     if (onExit) onExit();
-  }, [onExit]);
+  };
 
-  useEffect(() => {
-    function handleEscapeKeyDown(event: KeyboardEvent) {
-      if (event.code === 'Escape') {
-        event.preventDefault();
-        handleExit();
-      }
-    }
-
-    setTimeout(() => document.addEventListener('keydown', handleEscapeKeyDown));
-
-    return () => document.removeEventListener('keydown', handleEscapeKeyDown);
-  }, [handleExit]);
-
-  if (showModal === false) return null;
+  const handleAction = () => {
+    if (buttonOnClick) buttonOnClick();
+  };
 
   return (
-    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 h-full w-full flex items-center justify-center">
-      <div ref={ref} className="p-8 border w-96 rounded bg-white">
-        <div className="text-center">
-          <h3 className="text-2xl font-bold text-gray-900"> {text} </h3>
-          {buttonText &&
-            <Button
-              type='button'
-              size='lg'
-              className="abort-button-style mt-5"
-              onClick={() => {buttonOnClick && buttonOnClick();}}
-            >
-              {buttonText}
-            </Button>
-          }
+    <Modal
+      isOpen={showModal}
+      onClose={handleClose}
+      contentClassName="w-96"
+      primaryActionText={buttonText}
+      onPrimaryAction={buttonText ? handleAction : undefined}
+    >
+      <div className="flex items-center justify-center flex-col">
+        <div className="rounded-full bg-green-100 p-3 mb-4">
+          <FaCheck className="text-green-500" size={24} />
         </div>
+        <h3 className="text-2xl font-bold text-gray-900 text-center">
+          {text}
+        </h3>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/components/TitleNotFound.tsx
+++ b/src/components/TitleNotFound.tsx
@@ -1,10 +1,10 @@
 import {CatalogTitle} from '@/models/CatalogTitle';
 import WarningLabel from '@/components/WarningLabel';
 import {catalogDateStringToNorwegianDateString} from '@/utils/dateUtils';
-import {Button} from '@nextui-org/button';
 import {FaArrowAltCircleLeft, FaEdit} from 'react-icons/fa';
 import React from 'react';
 import {useRouter} from 'next/navigation';
+import AccessibleButton from '@/components/ui/AccessibleButton';
 
 interface TitleNotFoundProps {
   titleId: number;
@@ -34,24 +34,26 @@ const TitleNotFound = ({titleId, titleString, catalogTitle}: TitleNotFoundProps)
       <p className="mt-10 text-lg">Fant ikke kontakt- og utgivelsesinformasjon for denne tittelen. Ønsker du å
         legge til? </p>
       <div className="mt-12 flex justify-between max-w-3xl w-full self-center">
-        <Button
+        <AccessibleButton
           type="button"
-          size={'lg'}
+          variant='flat'
+          color='secondary'
+          size='lg'
           startContent={<FaArrowAltCircleLeft/>}
-          className="abort-button-style"
           onClick={() => router.push('/')}
         >
           Tilbake
-        </Button>
-        <Button
+        </AccessibleButton>
+        <AccessibleButton
           type="button"
-          size={'lg'}
-          className="edit-button-style"
+          variant='solid'
+          color='primary'
+          size='lg'
           endContent={<FaEdit/>}
           onClick={() => router.push(`/${titleId}/create?title=${titleString}`)}
         >
           Legg til informasjon
-        </Button>
+        </AccessibleButton>
       </div>
     </>
   );

--- a/src/components/WarningLabel.tsx
+++ b/src/components/WarningLabel.tsx
@@ -3,7 +3,7 @@ import { FaExclamationTriangle } from 'react-icons/fa';
 export default function WarningLabel(props: {text: string; className?: string}) {
   return (
     <div className={`flex items-center justify-center ${props.className}`}>
-      <div className={'w-96 h-16 bg-yellow-100 rounded-2xl font-bold flex flex-row items-center justify-center'}>
+      <div className={'w-96 h-16 bg-warning/25 rounded-2xl font-bold flex flex-row items-center justify-center'}>
         <FaExclamationTriangle className='mr-2.5' size={18}/>
         <h4>{props.text}</h4>
       </div>

--- a/src/components/ui/AccessibleButton.tsx
+++ b/src/components/ui/AccessibleButton.tsx
@@ -34,7 +34,7 @@ const AccessibleButton = forwardRef<HTMLButtonElement, AccessibleButtonProps>(
                 (triggerOnSpace && e.key === ' ')
       ) {
         e.preventDefault();
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
         onClick?.(e as any);
       }
     };

--- a/src/components/ui/AccessibleButton.tsx
+++ b/src/components/ui/AccessibleButton.tsx
@@ -1,20 +1,14 @@
 'use client';
 
-import React, { KeyboardEvent, forwardRef } from 'react';
+import React, { KeyboardEvent, MouseEvent, forwardRef, useRef } from 'react';
 import { Button, ButtonProps } from '@nextui-org/button';
 
 export type AccessibleButtonProps = ButtonProps & {
   /**
-     * Whether to trigger the button on Enter key press when focused
-     * @default true
-     */
+   * Whether to trigger the button on Enter key press when focused
+   * @default true
+   */
   triggerOnEnter?: boolean;
-
-  /**
-     * Whether to trigger the button on Space key press when focused
-     * @default true
-     */
-  triggerOnSpace?: boolean;
 };
 
 const AccessibleButton = forwardRef<HTMLButtonElement, AccessibleButtonProps>(
@@ -22,28 +16,54 @@ const AccessibleButton = forwardRef<HTMLButtonElement, AccessibleButtonProps>(
     {
       children,
       triggerOnEnter = true,
-      triggerOnSpace = true,
       onClick,
+      type,
       ...props
     },
     ref
   ) => {
+    const isProcessingEvent = useRef(false);
+
+    const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+      if (!isProcessingEvent.current) {
+        onClick?.(e);
+      }
+    };
+
     const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
-      if (
-        (triggerOnEnter && e.key === 'Enter') ||
-                (triggerOnSpace && e.key === ' ')
-      ) {
+      if (e.key === 'Enter' && triggerOnEnter && type !== 'submit') {
         e.preventDefault();
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-        onClick?.(e as any);
+
+        if (isProcessingEvent.current) {
+          return;
+        }
+
+        isProcessingEvent.current = true;
+
+        if (onClick) {
+          const syntheticEvent = {
+            currentTarget: e.currentTarget,
+            target: e.target,
+            preventDefault: () => e.preventDefault(),
+            stopPropagation: () => e.stopPropagation(),
+            isSyntheticEvent: true,
+          } as unknown as MouseEvent<HTMLButtonElement>;
+
+          onClick(syntheticEvent);
+        }
+
+        setTimeout(() => {
+          isProcessingEvent.current = false;
+        }, 100);
       }
     };
 
     return (
       <Button
         ref={ref}
-        onClick={onClick}
+        onClick={handleClick}
         onKeyDown={handleKeyDown}
+        type={type}
         {...props}
       >
         {children}

--- a/src/components/ui/AccessibleButton.tsx
+++ b/src/components/ui/AccessibleButton.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import React, { KeyboardEvent, forwardRef } from 'react';
+import { Button, ButtonProps } from '@nextui-org/button';
+
+export type AccessibleButtonProps = ButtonProps & {
+  /**
+     * Whether to trigger the button on Enter key press when focused
+     * @default true
+     */
+  triggerOnEnter?: boolean;
+
+  /**
+     * Whether to trigger the button on Space key press when focused
+     * @default true
+     */
+  triggerOnSpace?: boolean;
+};
+
+const AccessibleButton = forwardRef<HTMLButtonElement, AccessibleButtonProps>(
+  (
+    {
+      children,
+      triggerOnEnter = true,
+      triggerOnSpace = true,
+      onClick,
+      ...props
+    },
+    ref
+  ) => {
+    const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+      if (
+        (triggerOnEnter && e.key === 'Enter') ||
+                (triggerOnSpace && e.key === ' ')
+      ) {
+        e.preventDefault();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        onClick?.(e as any);
+      }
+    };
+
+    return (
+      <Button
+        ref={ref}
+        onClick={onClick}
+        onKeyDown={handleKeyDown}
+        {...props}
+      >
+        {children}
+      </Button>
+    );
+  }
+);
+
+AccessibleButton.displayName = 'AccessibleButton';
+
+export default AccessibleButton;

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import React, { ReactNode, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import AccessibleButton from '@/components/ui/AccessibleButton';
+
+export interface ModalProps {
+  /**
+     * Whether the modal is visible
+     */
+  isOpen: boolean;
+
+  /**
+     * Function to call when the modal should close
+     */
+  onClose: () => void;
+
+  /**
+     * Modal title/header
+     */
+  title?: string;
+
+  /**
+     * Modal content
+     */
+  children: ReactNode;
+
+  /**
+     * Primary action button text
+     */
+  primaryActionText?: string;
+
+  /**
+     * Primary action button handler
+     */
+  onPrimaryAction?: () => void;
+
+  /**
+     * Secondary action button text
+     */
+  secondaryActionText?: string;
+
+  /**
+     * Secondary action button handler
+     */
+  onSecondaryAction?: () => void;
+
+  /**
+     * Whether to automatically focus the first focusable element inside the modal
+     * @default true
+     */
+  autoFocus?: boolean;
+
+  /**
+     * Whether to close the modal when the escape key is pressed
+     * @default true
+     */
+  closeOnEscape?: boolean;
+
+  /**
+     * Whether to close the modal when clicking the overlay
+     * @default true
+     */
+  closeOnOverlayClick?: boolean;
+
+  /**
+     * Additional classes to apply to the modal content container
+     */
+  contentClassName?: string;
+}
+
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  primaryActionText,
+  onPrimaryAction,
+  secondaryActionText,
+  onSecondaryAction,
+  autoFocus = true,
+  closeOnEscape = true,
+  closeOnOverlayClick = true,
+  contentClassName = '',
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // Handle escape key
+  useEffect(() => {
+    if (!isOpen || !closeOnEscape) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose, closeOnEscape]);
+
+  // Handle body scroll lock
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  // Auto-focus first focusable element
+  useEffect(() => {
+    if (isOpen && autoFocus && contentRef.current) {
+      const focusableElements = contentRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+
+      if (focusableElements.length > 0) {
+        setTimeout(() => {
+          focusableElements[0].focus();
+        }, 50);
+      }
+    }
+  }, [isOpen, autoFocus]);
+
+  // Handle overlay click
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (closeOnOverlayClick && modalRef.current === e.target) {
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  // Use portal to render modal at the document body level
+  return createPortal(
+    <div
+      ref={modalRef}
+      className="fixed inset-0 bg-gray-600 bg-opacity-50 h-full w-full flex items-center justify-center z-50"
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        ref={contentRef}
+        className={`p-8 border rounded bg-white relative ${contentClassName}`}
+      >
+        {title && (
+          <h3 className="text-2xl font-bold text-gray-900 mb-4 text-center">
+            {title}
+          </h3>
+        )}
+
+        <div className="modal-body">
+          {children}
+        </div>
+
+        {(primaryActionText || secondaryActionText) && (
+          <div className="flex justify-center mt-6 gap-4">
+            {secondaryActionText && (
+              <AccessibleButton
+                variant='flat'
+                color='secondary'
+                onClick={onSecondaryAction || onClose}
+              >
+                {secondaryActionText}
+              </AccessibleButton>
+            )}
+
+            {primaryActionText && (
+              <AccessibleButton
+                variant='solid'
+                color='primary'
+                onClick={onPrimaryAction}
+              >
+                {primaryActionText}
+              </AccessibleButton>
+            )}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default Modal;

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -128,7 +128,6 @@ const Modal: React.FC<ModalProps> = ({
     }
   }, [isOpen, autoFocus]);
 
-  // Handle overlay click
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (closeOnOverlayClick && modalRef.current === e.target) {
       onClose();
@@ -137,7 +136,7 @@ const Modal: React.FC<ModalProps> = ({
 
   if (!isOpen) return null;
 
-  // Use portal to render modal at the document body level
+  // The portal will render modal at the document body level
   return createPortal(
     <div
       ref={modalRef}


### PR DESCRIPTION
This commit also refactors the usage of buttons and modals in the app to use the reusable versions. This makes buttons and modals behave consistently throughout the application.

It also cleans up the usage of colors, instead opting for using variables such as primary/secondary/warning/danger etc. from tailwind/HeroUI for more consistency and easier to identify call to action.